### PR TITLE
Add support for updating content in text files

### DIFF
--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -37,6 +37,7 @@
   const getBranchSha = require("../src/get-branch-sha");
   const createBranch = require("../src/create-branch");
   const removeBranch = require("../src/remove-branch");
+  const updateContent = require("../src/update-content");
 
   const octokit = new Octokit({
     auth: argv.pat || process.env.GITHUB_TOKEN,
@@ -148,6 +149,17 @@
         await removeBranch(owner, repo, old, octokit);
       }
     }
+
+    // Update all content on the branch
+    await updateContent(
+      owner,
+      repo,
+      old,
+      target,
+      octokit,
+      argv.verbose,
+      isDryRun
+    );
 
     // Add an empty new line to break up the output for each repo
     if (argv.verbose) {

--- a/src/update-content.js
+++ b/src/update-content.js
@@ -1,0 +1,84 @@
+module.exports = async function (
+  owner,
+  repo,
+  old,
+  target,
+  octokit,
+  isVerbose,
+  isDryRun
+) {
+  const replacements = {
+    "README.md": [
+      {
+        from: `@${old}`,
+        to: `@${target}`,
+      },
+      {
+        from: `${owner}/${repo}.svg?branch=${old}`,
+        to: `${owner}/${repo}.svg?branch=${target}`,
+      },
+    ],
+  };
+
+  for (let path in replacements) {
+    try {
+      let file = await loadFile(owner, repo, path, octokit);
+
+      let content = file.content;
+      for (let r of replacements[path]) {
+        var re = new RegExp(r.from, "g");
+        content = content.replace(re, r.to);
+      }
+
+      if (content !== file.content) {
+        if (isVerbose) {
+          console.log(`✏️  Updating [${path}]`);
+        }
+        if (!isDryRun) {
+          const r = await writeFile(
+            owner,
+            repo,
+            path,
+            content,
+            file.sha,
+            octokit
+          );
+        }
+      } else {
+        if (isVerbose) {
+          console.log(`✏️  No changes detected in [${path}]`);
+        }
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+};
+
+async function loadFile(owner, repo, path, octokit) {
+  const {
+    data: { sha, content },
+  } = await octokit.repos.getContent({
+    owner,
+    repo,
+    path,
+  });
+
+  return {
+    sha,
+    content: Buffer.from(content, "base64").toString(),
+  };
+}
+
+async function writeFile(owner, repo, path, content, sha, octokit) {
+  const { data: file } = await octokit.repos.createOrUpdateFileContents({
+    owner,
+    repo,
+    path,
+    message: `github-default-branch: Update ${path}`,
+    content: Buffer.from(content).toString("base64"),
+    sha,
+  });
+
+  return file;
+}


### PR DESCRIPTION
Replace common strings in text files. This code currently updates `README.md` and matches the following patterns:

* `@<old>` - For GitHub Actions repos
* `<org>/<repo>.svg?branch=<old>` - Travis badges

It might be worth switching to [this plugin](https://github.com/mheap/octokit-commit-multiple-files) if we edit multiple files to make all the changes in a single commit (and use less API requests)

This relates to #7 - @mathiasbynens are there any other patterns you'd like to ship in this version, or should we ship and add patterns as they come up in the future?