### PR TITLE
Add GitHub Enterprise compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,20 @@ Run with the `--verbose` flag to see debug information
 
 ## Options
 
-| Flag              | Description                                                    | Default |
-| ----------------- | -------------------------------------------------------------- | ------- |
-| --pat <token>     | GitHub API Token                                               | N/A     |
-| --repo <name>     | The repo to update (format: user/repo)                         | N/A     |
-| --user <name>     | Update all repos owned by the provided user (example: my-user) | N/A     |
-| --org <name>      | Update all repos in the provided org (example: my-org-name)    | N/A     |
-| --keep-old        | Keep the old branch rather than deleting it                    | false   |
-| --dry-run         | Output log messages only. Do not make any changes              | false   |
-| --list-repos-only | List repos that would be affected, then exit                   | false   |
-| --skip-forks      | Skips forked repositories                                      | false   |
-| --old             | The name of the branch to rename                               | master  |
-| --new             | The new branch name                                            | main    |
-| --confirm         | Run without prompting for confirmation                         | false   |
+| Flag                            | Description                                                    | Default |
+| ------------------------------- | -------------------------------------------------------------- | ------- |
+| --pat <token>                   | GitHub API Token                                               | N/A     |
+| --repo <name>                   | The repo to update (format: user/repo)                         | N/A     |
+| --user <name>                   | Update all repos owned by the provided user (example: my-user) | N/A     |
+| --org <name>                    | Update all repos in the provided org (example: my-org-name)    | N/A     |
+| --keep-old                      | Keep the old branch rather than deleting it                    | false   |
+| --dry-run                       | Output log messages only. Do not make any changes              | false   |
+| --list-repos-only               | List repos that would be affected, then exit                   | false   |
+| --skip-forks                    | Skips forked repositories                                      | false   |
+| --skip-update-branch-protection | Skip updating branch protections                               | false   |
+| --old                           | The name of the branch to rename                               | master  |
+| --new                           | The new branch name                                            | main    |
+| --confirm                       | Run without prompting for confirmation                         | false   |
 
 ## Replacements
 

--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -54,7 +54,8 @@
       },
       "base-url": {
         type: "string",
-        description: "Set a custom API base URL for use with GitHub Enterprise (example: https://github.example.com/api/v3)",
+        description:
+          "Set a custom API base URL for use with GitHub Enterprise (example: https://github.example.com/api/v3)",
       },
       // Plugin needed to use the old /git/refs/ API instead of the newer
       // /git/ref/ API introduced in v2.19.
@@ -63,7 +64,8 @@
       "enterprise-compatibility": {
         type: "boolean",
         default: false,
-        description: "Load Ocotkit plugin for improving compatibility with older versions of GitHub Enterprise API (needed for GitHub Enterprise versions before v2.19)",
+        description:
+          "Load Octokit plugin for improving compatibility with older versions of GitHub Enterprise API (needed for GitHub Enterprise versions before v2.19)",
       },
       // "updateBranchProtectionRule" GraphQL mutation not supported in
       // versions of the API prior to 2.15.
@@ -72,7 +74,8 @@
       "skip-update-branch-protection": {
         type: "boolean",
         default: false,
-        description: "Skip updating branch protection (not supported in GitHub Enterprise API versions before v2.15)",
+        description:
+          "Skip updating branch protection (not supported in GitHub Enterprise API versions before v2.15)",
       },
     })
     .example([
@@ -138,7 +141,9 @@
 
   let OctokitClass = Octokit;
   if (argv.enterpriseCompatibility) {
-    const { enterpriseCompatibility } = require("@octokit/plugin-enterprise-compatibility");
+    const {
+      enterpriseCompatibility,
+    } = require("@octokit/plugin-enterprise-compatibility");
     OctokitClass = Octokit.plugin(enterpriseCompatibility);
   }
 
@@ -164,7 +169,7 @@
       // GitHub Enterprise API versions may not support getting the rate
       // limits, so only log this as a warning, rather than treating errors as
       // fatal.
-      console.log(`⚠️  Unable to determine rate limits: ${e.message}\n`)
+      console.log(`⚠️  Unable to determine rate limits: ${e.message}\n`);
     }
   }
 

--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -52,6 +52,28 @@
         default: false,
         description: "Run without prompting for confirmation",
       },
+      "base-url": {
+        type: "string",
+        description: "Set a custom API base URL for use with GitHub Enterprise (example: https://github.example.com/api/v3)",
+      },
+      // Plugin needed to use the old /git/refs/ API instead of the newer
+      // /git/ref/ API introduced in v2.19.
+      // https://developer.github.com/enterprise/2.18/v3/git/refs/
+      // https://developer.github.com/enterprise/2.19/v3/git/refs/
+      "enterprise-compatibility": {
+        type: "boolean",
+        default: false,
+        description: "Load Ocotkit plugin for improving compatibility with older versions of GitHub Enterprise API (needed for GitHub Enterprise versions before v2.19)",
+      },
+      // "updateBranchProtectionRule" GraphQL mutation not supported in
+      // versions of the API prior to 2.15.
+      // https://developer.github.com/enterprise/2.14/v4/mutation/
+      // https://developer.github.com/enterprise/2.15/v4/mutation/
+      "skip-update-branch-protection": {
+        type: "boolean",
+        default: false,
+        description: "Skip updating branch protection (not supported in GitHub Enterprise API versions before v2.15)",
+      },
     })
     .example([
       ["$0 --pat <token> --repo user/repo", "Rename master to main"],
@@ -113,17 +135,36 @@
     return;
   }
 
-  const octokit = new Octokit({
+  let OctokitClass = Octokit;
+  if (argv.enterpriseCompatibility) {
+    const { enterpriseCompatibility } = require("@octokit/plugin-enterprise-compatibility");
+    OctokitClass = Octokit.plugin(enterpriseCompatibility);
+  }
+
+  let octokitArgs = {
     auth: argv.pat || process.env.GITHUB_TOKEN,
-  });
+  };
+
+  if (argv.baseUrl) {
+    octokitArgs.baseUrl = argv.baseUrl;
+  }
+
+  const octokit = new OctokitClass(octokitArgs);
 
   if (argv.verbose) {
-    const {
-      data: {
-        rate: { remaining },
-      },
-    } = await octokit.rateLimit.get();
-    console.log(`You have ${remaining} API requests remaining\n`);
+    try {
+      const {
+        data: {
+          rate: { remaining },
+        },
+      } = await octokit.rateLimit.get();
+      console.log(`You have ${remaining} API requests remaining\n`);
+    } catch (e) {
+      // GitHub Enterprise API versions may not support getting the rate
+      // limits, so only log this as a warning, rather than treating errors as
+      // fatal.
+      console.log(`⚠️  Unable to determine rate limits: ${e.message}\n`)
+    }
   }
 
   const repos = await getRepos(argv, octokit);
@@ -205,6 +246,10 @@
       await octokit.repos.update({
         owner,
         repo,
+        // The `name` parameter must be included for compatibility with older
+        // GitHub Enterprise API versions:
+        // https://github.community/t/cannot-change-default-branch/13728/13
+        name: repo,
         default_branch: target,
       });
     }
@@ -213,7 +258,7 @@
       console.log(`✏️  Changing branch protections`);
     }
 
-    if (!isDryRun) {
+    if (!isDryRun && !argv.skipUpdateBranchProtection) {
       await updateBranchProtection(owner, repo, old, target, octokit);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,15 @@
         "universal-user-agent": "^5.0.0"
       }
     },
+    "@octokit/plugin-enterprise-compatibility": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.5.tgz",
+      "integrity": "sha512-c909SIGuLV8/gF2qh5jwrWAu2+MdWbaeubQzTJjvSzeTY8JPlj5OVxHHKtIgc7JhJKhgt4a4+2eirnOR8LEcRw==",
+      "requires": {
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0"
+      }
+    },
     "@octokit/plugin-paginate-rest": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Michael Heap <m@michaelheap.com> (https://michaelheap.com)",
   "license": "MIT",
   "dependencies": {
+    "@octokit/plugin-enterprise-compatibility": "^1.2.5",
     "@octokit/rest": "^18.0.0",
     "prompt-confirm": "^2.0.4",
     "string.prototype.replaceall": "^1.0.3",


### PR DESCRIPTION
- Add `--base-url` argument for pointing at a GitHub Enterprise API URL.
- Add `--enterprise-compatibility` flag for loading the [`@octokit/plugin-enterprise-compatibility`](https://github.com/octokit/plugin-enterprise-compatibility.js/) plugin which is needed for the API to work against GitHub Enterprise's API before v2.19.
- Add `--skip-update-branch-protection` flag for skipping the update branch protection step. While this perhaps isn't ideal, this part of the GraphQL API wasn't supported until GitHub Enterprise API v2.15. If you weren't using protected branches, then this might be okay to skip.
- When running in verbose made, don't make failures to the rate limit API fatal, since GitHub Enterprise API versions may not support this endpoint.
- When updating the `default_branch` via the API, also pass the `name` parameter, which appears to be required for some older API versions: https://github.community/t/cannot-change-default-branch/13728/13