### PR TITLE
Update repos for an Org Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,21 @@ Run with the `--verbose` flag to see debug information
 
 ## Options
 
-| Flag                            | Description                                                    | Default |
-| ------------------------------- | -------------------------------------------------------------- | ------- |
-| --pat <token>                   | GitHub API Token                                               | N/A     |
-| --repo <name>                   | The repo to update (format: user/repo)                         | N/A     |
-| --user <name>                   | Update all repos owned by the provided user (example: my-user) | N/A     |
-| --org <name>                    | Update all repos in the provided org (example: my-org-name)    | N/A     |
-| --keep-old                      | Keep the old branch rather than deleting it                    | false   |
-| --dry-run                       | Output log messages only. Do not make any changes              | false   |
-| --list-repos-only               | List repos that would be affected, then exit                   | false   |
-| --skip-forks                    | Skips forked repositories                                      | false   |
-| --skip-update-branch-protection | Skip updating branch protections                               | false   |
-| --old                           | The name of the branch to rename                               | master  |
-| --new                           | The new branch name                                            | main    |
-| --confirm                       | Run without prompting for confirmation                         | false   |
+| Flag                            | Description                                                                                                      | Default |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| --pat <token>                   | GitHub API Token                                                                                                 | N/A     |
+| --repo <name>                   | The repo to update (format: user/repo)                                                                           | N/A     |
+| --user <name>                   | Update all repos owned by the provided user (example: my-user)                                                   | N/A     |
+| --org <name>                    | Update all repos in the provided org (example: my-org-name)                                                      | N/A     |
+| --team <name>                   | Update all repos in the provided team (example: my-team-name), only usable in combination with org parameter     | N/A     |
+| --keep-old                      | Keep the old branch rather than deleting it                                                                      | false   |
+| --dry-run                       | Output log messages only. Do not make any changes                                                                | false   |
+| --list-repos-only               | List repos that would be affected, then exit                                                                     | false   |
+| --skip-forks                    | Skips forked repositories                                                                                        | false   |
+| --skip-update-branch-protection | Skip updating branch protections                                                                                 | false   |
+| --old                           | The name of the branch to rename                                                                                 | master  |
+| --new                           | The new branch name                                                                                              | main    |
+| --confirm                       | Run without prompting for confirmation                                                                           | false   |
 
 ## Replacements
 

--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -17,6 +17,11 @@
         description:
           "Update all repos in the provided org (example: my-org-name)",
       },
+      team: {
+        type: "string",
+        description:
+          "Update all repos in the provided team (example: my-team-name), only usable in combination with org parameter",
+      },
       "keep-old": {
         type: "boolean",
         default: false,

--- a/src/get-repos.js
+++ b/src/get-repos.js
@@ -4,11 +4,23 @@ module.exports = async function (args, octokit) {
   }
 
   let repos = [];
-  if (args.org) {
+  if (args.org && !args.team) {
     repos = await octokit.paginate(
       octokit.repos.listForOrg,
       {
         org: args.org,
+        per_page: 100
+      },
+      (response) => response.data
+    );
+  }
+
+  if (args.org && args.team) {
+    repos = await octokit.paginate(
+      octokit.teams.listReposInOrg,
+      {
+        org: args.org,
+        team_slug: args.team,
         per_page: 100
       },
       (response) => response.data


### PR DESCRIPTION
Thanks your your amazing work for creating this node module to easily rename branches in a bunch of repositorys.

This PR makes it easier to rename master  -> main branche only in repositories which are linked to a team in an organization. 

If parameters org and team are provided all repos an existing team
are being looked up and updated. There is no functional change
on the existing org or user parameters.