### PR TITLE
Update GitHub Pages config

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = async (argv) => {
     let transforms = [
       "create-branch",
       "update-default-branch",
+      "github-pages",
       "retarget-pull-requests",
       "branch-protection",
       "delete-old-branch",

--- a/transforms/github-pages.js
+++ b/transforms/github-pages.js
@@ -1,0 +1,43 @@
+module.exports = async function ({
+  owner,
+  repo,
+  old,
+  target,
+  octokit,
+  log,
+  dryRun,
+}) {
+  log = log.extend("transforms:github-pages");
+
+  log("Updating GitHub Pages config");
+
+  try {
+    const {
+      data: { source },
+    } = await octokit.repos.getPages({
+      owner,
+      repo,
+    });
+
+    if (source.branch != old) {
+      log(
+        `Skipping GitHub pages as [${source.branch}] does not match [${old}]`
+      );
+      return;
+    }
+
+    source.branch = target;
+
+    await octokit.repos.updateInformationAboutPagesSite({
+      owner,
+      repo,
+      source,
+    });
+
+    log(
+      `Updated GitHub pages from [${old}] to [${target}] with path [${source.path}]`
+    );
+  } catch (e) {
+    log(`No GitHub Pages found for [${owner}/${repo}]`);
+  }
+};

--- a/transforms/github-pages.test.js
+++ b/transforms/github-pages.test.js
@@ -1,0 +1,115 @@
+const nock = require("nock");
+nock.disableNetConnect();
+
+const log = require("../src/mock-debug");
+const githubPages = require("./github-pages");
+
+const createBranch = require("./github-pages");
+const octokit = require("../src/octokit")();
+
+afterEach(() => {
+  if (!nock.isDone()) {
+    throw new Error("Not all nock interceptors were used");
+  }
+  log.cleanAll();
+  nock.cleanAll();
+});
+
+describe("#github-pages", () => {
+  it("continues with a log if pages is not enabled", async () => {
+    nock("https://api.github.com/").get("/repos/demo/repo/pages").reply(404);
+
+    await githubPages({
+      owner: "demo",
+      repo: "repo",
+      old: "master",
+      target: "main",
+      octokit,
+      log,
+    });
+
+    expect(log.logger).toBeCalledWith("No GitHub Pages found for [demo/repo]");
+  });
+
+  it("logs if the configured branch does not match the old branch", async () => {
+    nock("https://api.github.com/")
+      .get("/repos/demo/repo/pages")
+      .reply(200, {
+        source: {
+          branch: "custom",
+          path: "/",
+        },
+      });
+
+    await githubPages({
+      owner: "demo",
+      repo: "repo",
+      old: "master",
+      target: "main",
+      octokit,
+      log,
+    });
+
+    expect(log.logger).toBeCalledWith(
+      "Skipping GitHub pages as [custom] does not match [master]"
+    );
+  });
+
+  it("configures actions with the new branch", async () => {
+    nock("https://api.github.com/")
+      .get("/repos/demo/repo/pages")
+      .reply(200, {
+        source: {
+          branch: "master",
+          path: "/",
+        },
+      });
+
+    nock("https://api.github.com/")
+      .put("/repos/demo/repo/pages", { source: { branch: "main", path: "/" } })
+      .reply(200);
+
+    await githubPages({
+      owner: "demo",
+      repo: "repo",
+      old: "master",
+      target: "main",
+      octokit,
+      log,
+    });
+
+    expect(log.logger).toBeCalledWith(
+      "Updated GitHub pages from [master] to [main] with path [/]"
+    );
+  });
+
+  it("configures actions with the new branch (custom path)", async () => {
+    nock("https://api.github.com/")
+      .get("/repos/demo/repo/pages")
+      .reply(200, {
+        source: {
+          branch: "master",
+          path: "/docs",
+        },
+      });
+
+    nock("https://api.github.com/")
+      .put("/repos/demo/repo/pages", {
+        source: { branch: "main", path: "/docs" },
+      })
+      .reply(200);
+
+    await githubPages({
+      owner: "demo",
+      repo: "repo",
+      old: "master",
+      target: "main",
+      octokit,
+      log,
+    });
+
+    expect(log.logger).toBeCalledWith(
+      "Updated GitHub pages from [master] to [main] with path [/docs]"
+    );
+  });
+});


### PR DESCRIPTION
Add support for updating GitHub Pages configs if enabled on a repo. Supports repos using both `/` and `/docs` as a source

Resolves #16
Resolves #49 